### PR TITLE
Add Farsi READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,30 @@
-decentramind-mvp/
-├── llm-node/                  # Secure LLM inference node (FastAPI + Docker)
-│   ├── app/
-│   │   ├── main.py            # Entry point (FastAPI server)
-│   │   ├── model_runner.py    # Code to run model inference
-│   │   ├── crypto_utils.py    # RSA / AES encryption/decryption
-│   │   └── config.py          # Config vars & model settings
-│   ├── Dockerfile             # Docker build for LLM node
-│   ├── requirements.txt       # Python deps (FastAPI, cryptography, etc.)
-│   └── README.md
+# DecentraMind MVP
 
-├── client-dapp/               # Frontend app (Next.js or React + Tailwind)
-│   ├── pages/                 # Main dApp UI
-│   ├── components/            # ChatInput, WalletConnect, etc.
-│   ├── lib/crypto.ts          # AES + Curve25519 utils for encryption
-│   ├── public/
-│   ├── tailwind.config.js
+این مخزن نمونه‌ای برای اجرای یک نود استنتاج مدل زبانی به همراه رابط کاربری غیرمتمرکز است. پروژه شامل دو ماژول اصلی می‌باشد:
+
+- **llm-node**: پیاده‌سازی نود استنتاج با استفاده از FastAPI و کتابخانه‌های رمزنگاری. این نود پیام‌های رمزنگاری شده را دریافت و پاسخ را به صورت رمز شده برمی‌گرداند.
+- **client-dapp**: برنامه‌ی وب (Next.js) که کاربر از طریق آن پیام را رمز کرده و با نود ارتباط برقرار می‌کند.
+
+## ساختار کلی
+
+```text
+decentramind-mvp/
+├── llm-node/          # کد سرور FastAPI
+│   ├── app/
+│   │   ├── main.py
+│   │   ├── model_runner.py
+│   │   ├── crypto_utils.py
+│   │   └── keygen.py
+│   ├── requirements.txt
+│   └── README.md
+├── client-dapp/       # رابط کاربری Next.js
+│   ├── src/
+│   │   ├── app/
+│   │   ├── components/
+│   │   └── lib/
 │   ├── package.json
 │   └── README.md
+└── README.md          # همین فایل
+```
 
-├── .gitignore
-└── README.md                  # Main README with instructions
+برای راه‌اندازی هر بخش به README مربوطه مراجعه کنید.

--- a/client-dapp/README.md
+++ b/client-dapp/README.md
@@ -1,14 +1,19 @@
+# client-dapp
 
-## Getting Started
+این پوشه رابط کاربری مبتنی بر Next.js است که با استفاده از آن کاربر می‌تواند پیام‌های خود را رمزنگاری کرده و برای نود استنتاج ارسال کند.
 
-First, run the development server:
+## شروع به کار
+
+1. نصب وابستگی‌ها:
+
+```bash
+npm install
+```
+
+2. اجرای حالت توسعه:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
+
+برنامه بر روی آدرس پیش‌فرض `http://localhost:3000` در دسترس خواهد بود و درخواست‌ها را به سرور `llm-node` در آدرس `http://localhost:9000/infer` ارسال می‌کند.

--- a/llm-node/README.md
+++ b/llm-node/README.md
@@ -1,6 +1,23 @@
-uvicorn app.main:app --host 0.0.0.0 --port 9000
+# llm-node
 
-PRIVATE_KEY_BASE64: IF+alcQWuNRx5ZIEUspk0C4rDMuMJ4xxfRkS6xH56BI=
-PUBLIC_KEY_BASE64: q1VQYOOSsLaJeF2Ln4t0NBwbdPMlWn58teEWtNgGRy0=
+این پوشه شامل سرور FastAPI است که به عنوان نود استنتاج مدل زبانی عمل می‌کند. ارتباط بین کلاینت و سرور به صورت رمزنگاری شده بوده و پاسخ نیز به شکل رمز شده بازگردانده می‌شود.
 
+## راه‌اندازی سریع
+
+1. ایجاد و فعال‌سازی محیط مجازی:
+
+```bash
+python -m venv venv
 source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. اجرای سرور:
+
+```bash
+uvicorn app.main:app --host 0.0.0.0 --port 9000
+```
+
+3. در صورت نیاز به ایجاد کلید جدید می‌توانید اسکریپت `app/keygen.py` را اجرا کنید.
+
+کلاینت درخواست‌ها را به آدرس `/infer` ارسال می‌کند و بدنه‌ی درخواست شامل داده‌های رمز شده است.


### PR DESCRIPTION
## Summary
- add project overview in the root README
- document llm-node setup
- document client-dapp setup

## Testing
- `npm run lint` *(fails: next not found)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68620cdfe20883339467193328158c35